### PR TITLE
fix: attempt to fix sync-upstream job. 

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
           token: ${{ secrets.SYNC_TOKEN }}
       - name: Sync upstream changes
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
         with:
           target_sync_branch: main
           upstream_sync_branch: main
-          upstream_pull_args: '--allow-unrelated-histories'
+          upstream_pull_args: '-s recursive -Xtheirs --allow-unrelated-histories'
           upstream_sync_repo: corazawaf/coraza-proxy-wasm


### PR DESCRIPTION
Whenever upstream has a new commit, the sync job starts to fail and a manual push is needed. See https://github.com/tetrateio/coraza-proxy-wasm/actions/runs/9996347941/job/27630534890.